### PR TITLE
Remove setup_requires from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,6 @@ setup(name='iopipe',
       url='https://github.com/iopipe/iopipe-python',
       packages=['iopipe'],
       install_requires=reqs,
-      setup_requires=[
-          'flake8',
-          'pytest-runner'
-      ],
       extras_require={
           'dev': [
               'flake8'


### PR DESCRIPTION
## What I changed

Removed

```python
setup_requires=[
    'flake8',
    'pytest-runner'
],
```

as an argument to `setup()` in `setup.py`. 

## Why did I do this

**TL;DR:** [`flake8` requires `setuptools >= 30.0`](https://gitlab.com/pycqa/flake8/blob/6df26ffd57178e50194aea31b3bf9c572f91fa54/setup.py#L23). In the Python3.6 Docker image used in the [`serverless-python-requirements`](https://github.com/UnitedIncome/serverless-python-requirements) plugin, it has `setuptools==28.8.0` I don't think `flake8` is really needed for installation, so I'm removing it to ease install.

**Longer story:**

I'm trying to install IOPipe in a Serverless project using the [`serverless-python-requirements`](https://github.com/UnitedIncome/serverless-python-requirements) plugin. This plugin uses a Docker image to install Python plugins to avoid the headache in compiling C extensions for the proper platform for Lambda.

When I was trying to install the `iopipe` Python package, I was getting the following error:

```bash
bash-4.2# python3.6 -m pip --isolated install --no-clean -t reqs/ iopipe
Collecting iopipe
  Using cached iopipe-0.6.0.tar.gz
    Complete output from command python setup.py egg_info:
    zip_safe flag not set; analyzing archive contents...

    Installed /tmp/pip-build-wbi6q5ga/iopipe/.eggs/pytest_runner-2.11.1-py3.6.egg
    Searching for flake8
    Reading https://pypi.python.org/simple/flake8/
    Downloading https://pypi.python.org/packages/c8/82/13c6502074a8da93938de43b7386b60073afa528b07004643890ba02de9a/flake8-3.4.1.tar.gz#md5=9e084dfb3347b5cec88d4dedaf7552c6
    Best match: flake8 3.4.1
    Processing flake8-3.4.1.tar.gz
    Writing /tmp/easy_install-nzup5mpw/flake8-3.4.1/setup.cfg
    Running flake8-3.4.1/setup.py -q bdist_egg --dist-dir /tmp/easy_install-nzup5mpw/flake8-3.4.1/egg-dist-tmp-om_9moik
#!/usr/bin/env python
    zip_safe flag not set; analyzing archive contents...

    Installed /tmp/easy_install-nzup5mpw/flake8-3.4.1/.eggs/pytest_runner-2.11.1-py3.6.egg
    warning: no previously-included files matching '*.pyc' found anywhere in distribution
    no previously-included directories found matching 'docs/build/'
    zip_safe flag not set; analyzing archive contents...
    Moving flake8-3.4.1-py3.6.egg to /tmp/pip-build-wbi6q5ga/iopipe/.eggs

    Installed /tmp/pip-build-wbi6q5ga/iopipe/.eggs/flake8-3.4.1-py3.6.egg
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-wbi6q5ga/iopipe/setup.py", line 30, in <module>
        'pytest'
      File "/var/lang/lib/python3.6/distutils/core.py", line 108, in setup
        _setup_distribution = dist = klass(attrs)
      File "/var/lang/lib/python3.6/site-packages/setuptools/dist.py", line 316, in __init__
        self.fetch_build_eggs(attrs['setup_requires'])
      File "/var/lang/lib/python3.6/site-packages/setuptools/dist.py", line 365, in fetch_build_eggs
        replace_conflicting=True,
      File "/var/lang/lib/python3.6/site-packages/pkg_resources/__init__.py", line 850, in resolve
        dist = best[req.key] = env.best_match(req, ws, installer)
      File "/var/lang/lib/python3.6/site-packages/pkg_resources/__init__.py", line 1115, in best_match
        dist = working_set.find(req)
      File "/var/lang/lib/python3.6/site-packages/pkg_resources/__init__.py", line 719, in find
        raise VersionConflict(dist, req)
    pkg_resources.VersionConflict: (setuptools 28.8.0 (/var/lang/lib/python3.6/site-packages), Requirement.parse('setuptools>=30'))
```

I tracked it down to the `setuptools` requirement in `flake8`. Since flake8 isn't needed to use the `iopipe` library, I thought we could remove it from `setup_requires`. I removed `pytest-runner` for the same reasons.

Caveat: I know just enough pip + setuptools to be dangerous, so let me know if there's a valid reason for those packages to be in `setup_requires`. Don't want to break something for you all 😄.

