### PR TITLE
Check for numeric types without using longs

### DIFF
--- a/iopipe/iopipe.py
+++ b/iopipe/iopipe.py
@@ -36,6 +36,7 @@ class IOpipe(object):
 
         # Add numerical values to report
         # We typecast decimals as strings as they're not JSON serializable and
+        # casting them to floats can result in rounding errors
         if isinstance(value, numbers.Number) and \
                 not isinstance(value, decimal.Decimal):
             event['n'] = value

--- a/iopipe/iopipe.py
+++ b/iopipe/iopipe.py
@@ -1,10 +1,11 @@
-import sys
+import decimal
+import numbers
 import os
 
 import monotonic
 
-from .report import Report
 from .collector import get_collector_url
+from .report import Report
 
 
 class IOpipe(object):
@@ -34,10 +35,10 @@ class IOpipe(object):
         }
 
         # Add numerical values to report
-        if (isinstance(value, int) or
-            isinstance(value, float) or
-           (isinstance(value, long) if (sys.version_info[0] < 3) else False)):
-                event['n'] = value
+        # We typecast decimals as strings as they're not JSON serializable and
+        if isinstance(value, numbers.Number) and \
+                not isinstance(value, decimal.Decimal):
+            event['n'] = value
         else:
             event['s'] = str(value)
         self.report.custom_metrics.append(event)


### PR DESCRIPTION
Python includes a `numbers.Number` abstract class for numeric types. This is preferrable to handling `long` types by checking the Python version. It also makes linters happy.