### PR TITLE
Allow tests to be run via docker containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.gitignore
+.git
+README.md

--- a/Dockerfile.python2
+++ b/Dockerfile.python2
@@ -1,0 +1,12 @@
+FROM lambci/lambda:build-python2.7
+
+RUN mkdir -p /var/lib/iopipe
+
+WORKDIR /var/lib/iopipe
+
+RUN pip install pytest
+
+COPY . /var/lib/iopipe
+
+RUN python setup.py install
+RUN pytest

--- a/Dockerfile.python2
+++ b/Dockerfile.python2
@@ -4,9 +4,6 @@ RUN mkdir -p /var/lib/iopipe
 
 WORKDIR /var/lib/iopipe
 
-RUN pip install pytest
-
 COPY . /var/lib/iopipe
 
-RUN python setup.py install
-RUN pytest
+RUN python setup.py test

--- a/Dockerfile.python3
+++ b/Dockerfile.python3
@@ -1,0 +1,12 @@
+FROM lambci/lambda:build-python3.6
+
+RUN mkdir -p /var/lib/iopipe
+
+WORKDIR /var/lib/iopipe
+
+RUN pip install pytest
+
+COPY . /var/lib/iopipe
+
+RUN python setup.py install
+RUN pytest

--- a/Dockerfile.python3
+++ b/Dockerfile.python3
@@ -4,9 +4,6 @@ RUN mkdir -p /var/lib/iopipe
 
 WORKDIR /var/lib/iopipe
 
-RUN pip install pytest
-
 COPY . /var/lib/iopipe
 
-RUN python setup.py install
-RUN pytest
+RUN python setup.py test

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DOCKER_COMPOSE_YML?=docker-compose.yml
 test: test_python2 test_python3
 
 test_python2:
-	docker-compose -f ${DOCKER_COMPOSE_YML} build python2
+	docker-compose -f ${DOCKER_COMPOSE_YML} build --no-cache python2
 
 test_python3:
-	docker-compose -f ${DOCKER_COMPOSE_YML} build python3
+	docker-compose -f ${DOCKER_COMPOSE_YML} build --no-cache python3

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+SHELL=/bin/bash
+
+DOCKER_COMPOSE_YML?=docker-compose.yml
+
+test: test_python2 test_python3
+
+test_python2:
+	docker-compose -f ${DOCKER_COMPOSE_YML} build python2
+
+test_python3:
+	docker-compose -f ${DOCKER_COMPOSE_YML} build python3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '2'
+services:
+  python2:
+    build:
+      context: .
+      dockerfile: Dockerfile.python2
+
+  python3:
+    build:
+      context: .
+      dockerfile: Dockerfile.python3

--- a/iopipe/tests/test_agent.py
+++ b/iopipe/tests/test_agent.py
@@ -1,59 +1,79 @@
 import time
 
+import pytest
+
 from iopipe.iopipe import IOpipe
 
 from .MockContext import MockContext
 
-global advancedUsage
-global advancedUsageErr
 
-iopipe = IOpipe('test-suite', 'https://metrics-api.iopipe.com', True)
-context = MockContext('handler', '$LATEST')
-
-
-@iopipe.decorator
-def handler(event, context):
-    pass
+@pytest.fixture
+def iopipe():
+    return IOpipe('test-suite', 'https://metrics-api.iopipe.com', True)
 
 
-@iopipe.decorator
-def handlerWithEvents(event, context):
-    iopipe.log('somekey', 2)
-    iopipe.log('anotherkey', 'qualitative value')
+@pytest.fixture
+def mock_context():
+    return MockContext('handler', '$LATEST')
 
 
-@iopipe.decorator
-def handlerThatErrors(event, context):
-    raise ValueError("Behold, a value error")
+@pytest.fixture
+def handler(iopipe):
+    @iopipe.decorator
+    def _handler(event, context):
+        pass
+    return iopipe, _handler
 
 
-def setup_function():
-    handler(None, context)
+@pytest.fixture
+def handler_with_events(iopipe):
+    @iopipe.decorator
+    def _handler_with_events(event, context):
+        iopipe.log('somekey', 2)
+        iopipe.log('anotherkey', 'qualitative value')
+    return iopipe, _handler_with_events
+
+
+@pytest.fixture
+def handler_that_errors(iopipe):
+    @iopipe.decorator
+    def _handler_that_errors(event, context):
+        raise ValueError("Behold, a value error")
+    return iopipe, _handler_that_errors
 
 
 # N.B. this must be the first test!
-def test_coldstarts():
+def test_coldstarts(handler, mock_context):
+    iopipe, handler = handler
+    handler(None, mock_context)
     assert iopipe.report.coldstart
-    handler(None, context)
+
+    handler(None, mock_context)
     assert not iopipe.report.coldstart
 
 
-def test_client_id_is_configured():
+def test_client_id_is_configured(handler, mock_context):
+    iopipe, handler = handler
+    handler(None, mock_context)
     assert iopipe.report.client_id == 'test-suite'
 
 
-def test_function_name_from_context():
+def test_function_name_from_context(handler, mock_context):
+    iopipe, handler = handler
+    handler(None, mock_context)
     assert iopipe.report.aws['functionName'] == 'handler'
 
 
-def test_custom_metrics():
-    handlerWithEvents(None, context)
+def test_custom_metrics(handler_with_events, mock_context):
+    iopipe, handler = handler_with_events
+    handler(None, mock_context)
     assert len(iopipe.report.custom_metrics) == 2
 
 
-def test_erroring():
+def test_erroring(handler_that_errors, mock_context):
+    iopipe, handler = handler_that_errors
     try:
-        handlerThatErrors(None, context)
+        handler(None, mock_context)
     except:
         pass
     assert iopipe.report.errors['name'] == 'ValueError'
@@ -61,44 +81,54 @@ def test_erroring():
 
 
 # Advanced reporting
-def advancedHandler(event, context):
-    # make reference for testing
-    global advancedUsage
-    iopipe = IOpipe('test-suite')
-    advancedUsage = iopipe
-    timestamp = time.time()
-    report = iopipe.create_report(timestamp, context)
+@pytest.fixture
+def advanced_handler(iopipe):
+    mock_context = MockContext('advancedHandler', '1')
+
+    @iopipe.decorator
+    def _advanced_handler(event, context):
+        nested_iopipe = IOpipe('test-suite')
+        timestamp = time.time()
+        report = nested_iopipe.create_report(timestamp, context)
+        try:
+            pass
+        except Exception as e:
+            nested_iopipe.err(e)
+        # FIXME: For some reason the finally block isn't called for a nested
+        report.update_data(context, timestamp)
+        report.send()
+        return nested_iopipe
+
+    return _advanced_handler(None, mock_context)
+
+
+def test_advanced_reporting(advanced_handler):
+    assert advanced_handler.aws['functionName'] == 'advancedHandler'
+
+
+@pytest.fixture
+def advanced_handler_with_error(iopipe):
+    @iopipe.decorator
+    def _advanced_handler_with_error(event, context):
+        nested_iopipe = IOpipe('test-suite2')
+        timestamp = time.time()
+        report = nested_iopipe.create_report(timestamp, context)
+        nested_iopipe.log('name', 'foo')
+        try:
+            raise TypeError('Type error raised!')
+        except Exception as e:
+            nested_iopipe.err(e)
+        report.update_data(context, timestamp)
+        report.send()
+        return nested_iopipe
+
+    return _advanced_handler_with_error
+
+
+def test_advanced_erroring(advanced_handler_with_error, mock_context):
     try:
-        pass
-    except Exception as e:
-        iopipe.err(e)
-    report.send()
-
-
-def test_advanced_reporting():
-    new_context = MockContext('advancedHandler', '1')
-    advancedHandler(None, new_context)
-    assert(advancedUsage.report.aws['functionName']) == 'advancedHandler'
-
-
-def advancedHandlerWithErr(event, context):
-    global advancedUsageErr
-    iopipe = IOpipe('test-suite2')
-    advancedUsageErr = iopipe
-    timestamp = time.time()
-    report = iopipe.create_report(timestamp, context)
-    iopipe.log('name', 'foo')
-    try:
-        raise TypeError('Type error raised!')
-    except Exception as e:
-        iopipe.err(e)
-    report.send()
-
-
-def test_advanced_erroring():
-    try:
-        advancedHandlerWithErr(None, context)
+        nested_iopipe = advanced_handler_with_error(None, mock_context)
     except:
         pass
-    assert advancedUsageErr.report.errors['name'] == 'TypeError'
-    assert advancedUsageErr.report.errors['message'] == 'Type error raised!'
+    assert nested_iopipe.report.errors['name'] == 'TypeError'
+    assert nested_iopipe.report.errors['message'] == 'Type error raised!'

--- a/iopipe/tests/test_agent.py
+++ b/iopipe/tests/test_agent.py
@@ -83,52 +83,57 @@ def test_erroring(handler_that_errors, mock_context):
 # Advanced reporting
 @pytest.fixture
 def advanced_handler(iopipe):
-    mock_context = MockContext('advancedHandler', '1')
+    nested_iopipe = []
 
     @iopipe.decorator
     def _advanced_handler(event, context):
-        nested_iopipe = IOpipe('test-suite')
+        nested_iopipe.append(IOpipe('test-suite'))
         timestamp = time.time()
-        report = nested_iopipe.create_report(timestamp, context)
+        report = nested_iopipe[0].create_report(timestamp, context)
         try:
             pass
         except Exception as e:
-            nested_iopipe.err(e)
-        # FIXME: For some reason the finally block isn't called for a nested
+            nested_iopipe[0].err(e)
         report.update_data(context, timestamp)
         report.send()
-        return nested_iopipe
 
-    return _advanced_handler(None, mock_context)
+    return nested_iopipe, _advanced_handler
 
 
 def test_advanced_reporting(advanced_handler):
-    assert advanced_handler.aws['functionName'] == 'advancedHandler'
+
+    mock_context = MockContext('advancedHandler', '1')
+    nested_iopipe, handler = advanced_handler
+    handler(None, mock_context)
+    assert nested_iopipe[0].report.aws['functionName'] == 'advancedHandler'
 
 
 @pytest.fixture
 def advanced_handler_with_error(iopipe):
+    nested_iopipe = []
+
     @iopipe.decorator
     def _advanced_handler_with_error(event, context):
-        nested_iopipe = IOpipe('test-suite2')
+        nested_iopipe.append(IOpipe('test-suite2'))
         timestamp = time.time()
-        report = nested_iopipe.create_report(timestamp, context)
-        nested_iopipe.log('name', 'foo')
+        report = nested_iopipe[0].create_report(timestamp, context)
+        nested_iopipe[0].log('name', 'foo')
         try:
             raise TypeError('Type error raised!')
         except Exception as e:
-            nested_iopipe.err(e)
-        report.update_data(context, timestamp)
+            nested_iopipe[0].err(e)
         report.send()
-        return nested_iopipe
 
-    return _advanced_handler_with_error
+    return nested_iopipe, _advanced_handler_with_error
 
 
 def test_advanced_erroring(advanced_handler_with_error, mock_context):
+
+    mock_context = MockContext('advancedHandler', '1')
+    nested_iopipe, handler = advanced_handler_with_error
     try:
-        nested_iopipe = advanced_handler_with_error(None, mock_context)
-    except:
+        handler(None, mock_context)
+    except Exception:
         pass
-    assert nested_iopipe.report.errors['name'] == 'TypeError'
-    assert nested_iopipe.report.errors['message'] == 'Type error raised!'
+    assert nested_iopipe[0].report.errors['name'] == 'TypeError'
+    assert nested_iopipe[0].report.errors['message'] == 'Type error raised!'

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(name='iopipe',
               'flake8'
           ]
       },
-      tests_require=[
-          'pytest'
-      ]
+      setup_requires=['pytest-runner'],
+      tests_require=['pytest']
       )


### PR DESCRIPTION
For OSX users such as myself, the tests fail because they're dependent on a Linux kernel. This adds a `make test` task that will run these tests in lambda python2 and python3 containers.