### PR TITLE
Feature/disable iopipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ def handler(event, context):
 
 This makes it easy to add custom data and telemetry within your function.
 
+### Disabling IOpipe
+
+If you need to disable IOpipe monitoring during development or in any other situation you can set `IOPIPE_ENABLED` environment variable to `False`.
+
+Default for `IOPIPE_ENABLED` environment variable is `True`.
+
 ## Copyright
 
 Provided under the Apache-2.0 license. See LICENSE for details.

--- a/iopipe/config.py
+++ b/iopipe/config.py
@@ -50,7 +50,7 @@ def is_enabled():
     Default is True.
     Useful for running function locally.
 
-    :returns: True if enabled
+    :returns: True if enabled, False if disabled
     :rtype: bool
     """
     env_var = os.getenv('IOPIPE_ENABLED')

--- a/iopipe/config.py
+++ b/iopipe/config.py
@@ -15,7 +15,7 @@ def set_config(**config):
     config.setdefault('network_timeout', 5000)
     config.setdefault('timeout_window', os.getenv('IOPIPE_TIMEOUT_WINDOW', 150))
     config.setdefault('install_method', 'manual')
-    config.setdefault('enabled', is_enabled())
+    config.setdefault('enabled', bool(strtobool(os.getenv('IOPIPE_ENABLED', 'true'))))
     config.setdefault('plugins', [])
 
     if 'url' in config:
@@ -41,20 +41,3 @@ def set_config(**config):
         config['timeout_window'] = 150
 
     return config
-
-
-def is_enabled():
-    """
-    Check if IOPIPE_ENABLED environment variable is set to False.
-    If so, IOpipe reporting will be skipped.
-    Default is True.
-    Useful for running function locally.
-
-    :returns: True if enabled, False if disabled
-    :rtype: bool
-    """
-    env_var = os.getenv('IOPIPE_ENABLED')
-    if env_var:
-        return bool(strtobool(env_var))
-    else:
-        return True

--- a/iopipe/config.py
+++ b/iopipe/config.py
@@ -1,3 +1,4 @@
+from distutils.util import strtobool
 import os
 
 from .collector import get_collector_path, get_hostname
@@ -14,6 +15,7 @@ def set_config(**config):
     config.setdefault('network_timeout', 5000)
     config.setdefault('timeout_window', os.getenv('IOPIPE_TIMEOUT_WINDOW', 150))
     config.setdefault('install_method', 'manual')
+    config.setdefault('enabled', is_enabled())
     config.setdefault('plugins', [])
 
     if 'url' in config:
@@ -39,3 +41,20 @@ def set_config(**config):
         config['timeout_window'] = 150
 
     return config
+
+
+def is_enabled():
+    """
+    Check if IOPIPE_ENABLED environment variable is set to False.
+    If so, IOpipe reporting will be skipped.
+    Default is True.
+    Useful for running function locally.
+
+    :returns: True if enabled
+    :rtype: bool
+    """
+    env_var = os.getenv('IOPIPE_ENABLED')
+    if env_var:
+        return bool(strtobool(env_var))
+    else:
+        return True

--- a/iopipe/iopipe.py
+++ b/iopipe/iopipe.py
@@ -49,6 +49,10 @@ class IOpipe(object):
 
     def decorator(self, fun):
         def wrapped(event, context):
+            # if env var IOPIPE_ENABLED is set to False skip reporting
+            if self.config['enabled'] is False:
+                return fun(event, context)
+
             if not self.config['client_id']:
                 warnings.warn('Your function is decorated with iopipe, but a valid token was not found.')
 

--- a/iopipe/tests/test_config.py
+++ b/iopipe/tests/test_config.py
@@ -8,15 +8,29 @@ def test_set_config__iopipe_enabled__default():
     assert config['enabled'] is True
 
 
-def test_set_config__iopipe_enabled__disabled():
+def test_set_config__iopipe_enabled__title_case_true():
+    os.environ['IOPIPE_ENABLED'] = 'True'
+
+    config = set_config()
+    assert config['enabled'] is True
+
+
+def test_set_config__iopipe_enabled__small_caps_true():
+    os.environ['IOPIPE_ENABLED'] = 'true'
+
+    config = set_config()
+    assert config['enabled'] is True
+
+
+def test_set_config__iopipe_enabled__title_case_false():
     os.environ['IOPIPE_ENABLED'] = 'False'
 
     config = set_config()
     assert config['enabled'] is False
 
 
-def test_set_config__iopipe_enabled__enabled():
-    os.environ['IOPIPE_ENABLED'] = 'True'
+def test_set_config__iopipe_enabled__small_caps_false():
+    os.environ['IOPIPE_ENABLED'] = 'false'
 
     config = set_config()
-    assert config['enabled'] is True
+    assert config['enabled'] is False

--- a/iopipe/tests/test_config.py
+++ b/iopipe/tests/test_config.py
@@ -1,0 +1,27 @@
+import os
+
+from iopipe.config import is_enabled
+
+
+def test_is_enabled_default():
+    assert is_enabled() is True
+
+
+def test_is_enabled_small_caps_true():
+    os.environ['IOPIPE_ENABLED'] = 'true'
+    assert is_enabled() is True
+
+
+def test_is_enabled_title_case_true():
+    os.environ['IOPIPE_ENABLED'] = 'True'
+    assert is_enabled() is True
+
+
+def test_is_enabled_small_caps_false():
+    os.environ['IOPIPE_ENABLED'] = 'false'
+    assert is_enabled() is False
+
+
+def test_is_enabled_title_case_false():
+    os.environ['IOPIPE_ENABLED'] = 'False'
+    assert is_enabled() is False

--- a/iopipe/tests/test_config.py
+++ b/iopipe/tests/test_config.py
@@ -1,27 +1,22 @@
 import os
 
-from iopipe.config import is_enabled
+from iopipe.config import set_config
 
 
-def test_is_enabled_default():
-    assert is_enabled() is True
+def test_set_config__iopipe_enabled__default():
+    config = set_config()
+    assert config['enabled'] is True
 
 
-def test_is_enabled_small_caps_true():
-    os.environ['IOPIPE_ENABLED'] = 'true'
-    assert is_enabled() is True
-
-
-def test_is_enabled_title_case_true():
-    os.environ['IOPIPE_ENABLED'] = 'True'
-    assert is_enabled() is True
-
-
-def test_is_enabled_small_caps_false():
-    os.environ['IOPIPE_ENABLED'] = 'false'
-    assert is_enabled() is False
-
-
-def test_is_enabled_title_case_false():
+def test_set_config__iopipe_enabled__disabled():
     os.environ['IOPIPE_ENABLED'] = 'False'
-    assert is_enabled() is False
+
+    config = set_config()
+    assert config['enabled'] is False
+
+
+def test_set_config__iopipe_enabled__enabled():
+    os.environ['IOPIPE_ENABLED'] = 'True'
+
+    config = set_config()
+    assert config['enabled'] is True


### PR DESCRIPTION
I'm suggesting an option to disable IOpipe plugin using environment variable.

It's useful to disable IOpipe during local development or if someone want's to disable logging just temporary or for staging or anything like that.

If env var `IOPIPE_ENABLED` is set to `False` IOpipe reporting is disabled. Default is `True`.