### PR TITLE
Fix system calls

### DIFF
--- a/iopipe/report.py
+++ b/iopipe/report.py
@@ -11,7 +11,7 @@ import monotonic
 from . import constants
 from .send_report import send_report
 
-if sys.platform == 'linux2':
+if sys.platform.startswith('linux'):
     from . import system
 else:
     from . import mock_system as system


### PR DESCRIPTION
The mock system was always being called, resulting in missing/incorrect data. This updates it to check with `startswith` for linux. More detail here if you're curious: https://stackoverflow.com/questions/10415942/python-sys-platform-linux2-but-not-linux3