### PR TITLE
Adding timeout handling

### DIFF
--- a/Dockerfile.python2
+++ b/Dockerfile.python2
@@ -1,6 +1,8 @@
 FROM lambci/lambda:build-python2.7
 
-RUN pip install -U setuptools && mkdir -p /var/lib/iopipe
+RUN pip install -U setuptools
+
+RUN mkdir -p /var/lib/iopipe
 
 WORKDIR /var/lib/iopipe
 

--- a/Dockerfile.python2
+++ b/Dockerfile.python2
@@ -1,9 +1,9 @@
 FROM lambci/lambda:build-python2.7
 
-RUN mkdir -p /var/lib/iopipe
+RUN pip install -U setuptools && mkdir -p /var/lib/iopipe
 
 WORKDIR /var/lib/iopipe
 
 COPY . /var/lib/iopipe
 
-RUN pip install -U setuptools && python setup.py test
+RUN python setup.py test

--- a/Dockerfile.python3
+++ b/Dockerfile.python3
@@ -1,5 +1,7 @@
 FROM lambci/lambda:build-python3.6
 
+RUN pip install -U setuptools
+
 RUN mkdir -p /var/lib/iopipe
 
 WORKDIR /var/lib/iopipe

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Debug mode will log all data sent to IOpipe servers. This is also a good way to 
 
 Conditionally enable/disable the agent. For example, you will likely want to disabled the agent during development. The environment variable `$IOPIPE_ENABLED` will also be checked.
 
+#### `timeout_window` (float|int: optional = 1.5)
+
+By default, IOpipe will capture timeouts by exiting your function 1.5 seconds early from the AWS configured timeout, to allow time for reporting. You can disable this feature by setting `timeout_window` to `0` in your configuration. If not supplied, the environment variable `$IOPIPE_TIMEOUT_WINDOW` will be used if present.
+
 ### Reporting Exceptions
 
 The IOpipe decorator will automatically catch, trace and reraise any uncaught exceptions in your function. If you want to trace exceptions raised in your case, you can use the `.error(exception)` method. This will add the exception to the current report.

--- a/iopipe/config.py
+++ b/iopipe/config.py
@@ -15,7 +15,7 @@ def set_config(**config):
     config.setdefault('network_timeout', 5)
     config.setdefault('path', get_collector_path())
     config.setdefault('plugins', [])
-    config.setdefault('timeout_window', os.getenv('IOPIPE_TIMEOUT_WINDOW', 150))
+    config.setdefault('timeout_window', os.getenv('IOPIPE_TIMEOUT_WINDOW', 1500))
     config.setdefault('token', os.getenv('IOPIPE_TOKEN') or os.getenv('IOPIPE_CLIENTID') or '')
 
     if 'client_id' in config:

--- a/iopipe/config.py
+++ b/iopipe/config.py
@@ -15,7 +15,7 @@ def set_config(**config):
     config.setdefault('network_timeout', 5)
     config.setdefault('path', get_collector_path())
     config.setdefault('plugins', [])
-    config.setdefault('timeout_window', os.getenv('IOPIPE_TIMEOUT_WINDOW', 1500))
+    config.setdefault('timeout_window', os.getenv('IOPIPE_TIMEOUT_WINDOW', 1.5))
     config.setdefault('token', os.getenv('IOPIPE_TOKEN') or os.getenv('IOPIPE_CLIENTID') or '')
 
     if 'client_id' in config:
@@ -38,8 +38,8 @@ def set_config(**config):
         config['network_timeout'] = 5
 
     try:
-        config['timeout_window'] = int(config['timeout_window'])
+        config['timeout_window'] = float(config['timeout_window'])
     except ValueError:
-        config['timeout_window'] = 150
+        config['timeout_window'] = 1.5
 
     return config

--- a/iopipe/iopipe.py
+++ b/iopipe/iopipe.py
@@ -94,7 +94,8 @@ class IOpipe(object):
 
                 logger.debug('Setting timeout duration to %s' % timeout_duration)
 
-                # Using signal.setitimer instead of signal.alarm because the latter only accepts seconds
+                # Using signal.setitimer instead of signal.alarm because the latter only accepts integers and we want to
+                # be able to timeout at millisecond granularity
                 signal.setitimer(signal.ITIMER_REAL, timeout_duration)
 
             result = None

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(name='iopipe',
               'flake8'
           ]
       },
-      setup_requires=['pytest-runner'],
+      setup_requires=['flake8', 'pytest-runner'],
       tests_require=['mock', 'pytest', 'requests']
       )

--- a/tests/mock_context.py
+++ b/tests/mock_context.py
@@ -1,5 +1,4 @@
 class MockContext(object):
-    function_version = '$LATEST'
     aws_request_id = '0'
     log_group_name = 'mock-group'
     log_stream_name = 'mock-stream'
@@ -8,8 +7,11 @@ class MockContext(object):
     def __init__(self, name='handler', version='$LATEST'):
         self.function_name = name
         self.function_version = version
-        self.invoked_function_arn = """arn:aws:lambda:us-east-1:1:
-            function:%s:%s""" % (name, version)
+        self.invoked_function_arn = 'arn:aws:lambda:us-east-1:1:function:%s:%s' % (name, version)
+        self.remaining_time_in_millis = float('inf')
 
     def get_remaining_time_in_millis(self):
-        return float('inf')
+        return self.remaining_time_in_millis
+
+    def set_remaining_time_in_millis(self, time_remaining):
+        self.remaining_time_in_millis = time_remaining

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -47,7 +47,7 @@ def handler_that_errors(iopipe):
 def handler_that_timeouts(iopipe):
     @iopipe.decorator
     def _handler_that_timeouts(event, context):
-        time.sleep(5)
+        time.sleep(2)
         raise Exception('Should timeout before this is raised')
     return iopipe, _handler_that_timeouts
 
@@ -114,7 +114,7 @@ def test_erroring(mock_send_report, handler_that_errors, mock_context):
 def test_timeouts(mock_send_report, handler_that_timeouts, mock_context):
     """Assert that the agent timeouts before function does"""
     iopipe, handler = handler_that_timeouts
-    mock_context.set_remaining_time_in_millis(200)
+    mock_context.set_remaining_time_in_millis(2000)
 
     try:
         handler(None, mock_context)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,3 +1,6 @@
+import time
+
+import mock
 import pytest
 
 from iopipe import constants, IOpipe
@@ -40,9 +43,19 @@ def handler_that_errors(iopipe):
     return iopipe, _handler_that_errors
 
 
-def test_coldstarts(handler, mock_context, monkeypatch):
-    monkeypatch.setattr(constants, 'COLDSTART', True)
+@pytest.fixture
+def handler_that_timeouts(iopipe):
+    @iopipe.decorator
+    def _handler_that_timeouts(event, context):
+        time.sleep(5)
+        raise Exception('Should timeout before this is raised')
+    return iopipe, _handler_that_timeouts
 
+
+@mock.patch('iopipe.report.send_report', autospec=True)
+def test_coldstarts(mock_send_report, handler, mock_context, monkeypatch):
+    """Assert that cold start is true on first invocation and false on next"""
+    monkeypatch.setattr(constants, 'COLDSTART', True)
     iopipe, handler = handler
 
     handler(None, mock_context)
@@ -52,29 +65,61 @@ def test_coldstarts(handler, mock_context, monkeypatch):
     assert iopipe.report.report['coldstart'] is False
 
 
-def test_client_id_is_configured(handler, mock_context):
+@mock.patch('iopipe.report.send_report', autospec=True)
+def test_client_id_is_configured(mock_send_report, handler, mock_context):
+    """Assert that the agent configures the client_id correctly"""
     iopipe, handler = handler
     handler(None, mock_context)
+
     assert iopipe.report.report['client_id'] == 'test-suite'
+    mock_send_report.assert_called_once_with(iopipe.report.report, iopipe.config)
 
 
-def test_function_name_from_context(handler, mock_context):
+@mock.patch('iopipe.report.send_report', autospec=True)
+def test_function_name_from_context(mock_send_report, handler, mock_context):
+    """Assert that the agent extracts the function name from the context"""
     iopipe, handler = handler
     handler(None, mock_context)
+
     assert iopipe.report.report['aws']['functionName'] == 'handler'
+    mock_send_report.assert_called_once_with(iopipe.report.report, iopipe.config)
 
 
-def test_custom_metrics(handler_with_events, mock_context):
+@mock.patch('iopipe.report.send_report', autospec=True)
+def test_custom_metrics(mock_send_report, handler_with_events, mock_context):
+    """Assert that the agent collects custom metrics"""
     iopipe, handler = handler_with_events
     handler(None, mock_context)
+
     assert len(iopipe.report.custom_metrics) == 2
+    mock_send_report.assert_called_once_with(iopipe.report.report, iopipe.config)
 
 
-def test_erroring(handler_that_errors, mock_context):
+@mock.patch('iopipe.report.send_report', autospec=True)
+def test_erroring(mock_send_report, handler_that_errors, mock_context):
+    """Assert that the agent catches and traces uncaught exceptions"""
     iopipe, handler = handler_that_errors
+
     try:
         handler(None, mock_context)
-    except:
+    except Exception:
         pass
+
     assert iopipe.report.report['errors']['name'] == 'ValueError'
     assert iopipe.report.report['errors']['message'] == 'Behold, a value error'
+    mock_send_report.assert_called_once_with(iopipe.report.report, iopipe.config)
+
+
+@mock.patch('iopipe.report.send_report', autospec=True)
+def test_timeouts(mock_send_report, handler_that_timeouts, mock_context):
+    """Assert that the agent timeouts before function does"""
+    iopipe, handler = handler_that_timeouts
+    mock_context.set_remaining_time_in_millis(200)
+
+    try:
+        handler(None, mock_context)
+    except Exception:
+         pass
+
+    assert iopipe.report.report['errors'] == {}
+    mock_send_report.assert_called_once_with(iopipe.report.report, iopipe.config)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -123,3 +123,22 @@ def test_timeouts(mock_send_report, handler_that_timeouts, mock_context):
 
     assert iopipe.report.report['errors'] == {}
     mock_send_report.assert_called_once_with(iopipe.report.report, iopipe.config)
+
+
+@mock.patch('iopipe.report.send_report', autospec=True)
+def test_timeouts_disable(mock_send_report, handler_that_timeouts, mock_context):
+    """Assert the timeout is disabled if insufficient time remaining"""
+    iopipe, handler = handler_that_timeouts
+
+    # The default is 1.5, so 1500 / 100 - 1.5 = 0
+    mock_context.set_remaining_time_in_millis(1500)
+
+    try:
+        handler(None, mock_context)
+    except Exception:
+         pass
+
+    # Exception will occur because timeout is disabled
+    assert iopipe.report.report['errors'] != {}
+    assert iopipe.report.report['errors']['name'] == 'Exception'
+    assert iopipe.report.report['errors']['message'] == 'Should timeout before this is raised'

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 import json
 import numbers
 import sys
@@ -5,12 +6,18 @@ import sys
 import mock
 import pytest
 import requests
+=======
+import mock
+import pytest
+import sys
+>>>>>>> Fix sys.platform checks, add report test to check for system fields
 
 from iopipe.config import set_config
 from iopipe.report import Report
 
 from .mock_context import MockContext
 
+<<<<<<< HEAD
 SCHEMA_JSON_URL = 'https://raw.githubusercontent.com/iopipe/iopipe/master/src/schema.json'
 
 
@@ -55,6 +62,11 @@ def assert_valid_schema(obj, schema=None, path=None, optional_fields=None):
 def test_report_linux_system_success(mock_send_report):
     """Asserts that fields collected by the system module are present in a success report"""
 
+=======
+
+@mock.patch('iopipe.report.send_report')
+def test_report_linux_system(mock_send_report):
+>>>>>>> Fix sys.platform checks, add report test to check for system fields
     if not sys.platform.startswith('linux'):
         pytest.skip('this test requires linux, skipping')
 
@@ -63,6 +75,7 @@ def test_report_linux_system_success(mock_send_report):
     report = Report(set_config(), mock_context)
     report.send()
 
+<<<<<<< HEAD
     assert_valid_schema(report.report, optional_fields=[
         'aws.traceId',
         'environment.nodejs',
@@ -104,3 +117,28 @@ def test_report_linux_system_error(mock_send_report):
         'performanceEntries',
         'timestampEnd',
     ])
+=======
+    assert 'aws' in report.report
+
+    for key in ['functionName', 'functionVersion', 'awsRequestId',
+                'invokedFunctionArn', 'logGroupName', 'logStreamName',
+                'memoryLimitInMB', 'getRemainingTimeInMillis']:
+        assert key in report.report['aws']
+
+    assert 'cpus' in report.report['environment']['os']
+
+    for cpu in report.report['environment']['os']['cpus']:
+        assert 'times' in cpu
+        for key in ['idle', 'irq', 'sys', 'user', 'nice']:
+            assert key in cpu['times']
+
+    assert 'freemem' in report.report['environment']['os']
+    assert 'totalmem' in report.report['environment']['os']
+
+    for key in ['utime', 'stime', 'cutime', 'cstime', 'rss']:
+        assert key in report.report['environment']['os']['linux']['pid']['self']['stat']
+        assert key in report.report['environment']['os']['linux']['pid']['self']['stat_start']
+
+    for key in ['VmRSS', 'Threads', 'FDSize']:
+        assert key in report.report['environment']['os']['linux']['pid']['self']['status']
+>>>>>>> Fix sys.platform checks, add report test to check for system fields

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 import json
 import numbers
 import sys
@@ -6,18 +5,12 @@ import sys
 import mock
 import pytest
 import requests
-=======
-import mock
-import pytest
-import sys
->>>>>>> Fix sys.platform checks, add report test to check for system fields
 
 from iopipe.config import set_config
 from iopipe.report import Report
 
 from .mock_context import MockContext
 
-<<<<<<< HEAD
 SCHEMA_JSON_URL = 'https://raw.githubusercontent.com/iopipe/iopipe/master/src/schema.json'
 
 
@@ -61,12 +54,6 @@ def assert_valid_schema(obj, schema=None, path=None, optional_fields=None):
 @mock.patch('iopipe.report.send_report')
 def test_report_linux_system_success(mock_send_report):
     """Asserts that fields collected by the system module are present in a success report"""
-
-=======
-
-@mock.patch('iopipe.report.send_report')
-def test_report_linux_system(mock_send_report):
->>>>>>> Fix sys.platform checks, add report test to check for system fields
     if not sys.platform.startswith('linux'):
         pytest.skip('this test requires linux, skipping')
 
@@ -75,7 +62,6 @@ def test_report_linux_system(mock_send_report):
     report = Report(set_config(), mock_context)
     report.send()
 
-<<<<<<< HEAD
     assert_valid_schema(report.report, optional_fields=[
         'aws.traceId',
         'environment.nodejs',
@@ -94,7 +80,6 @@ def test_report_linux_system(mock_send_report):
 @mock.patch('iopipe.report.send_report')
 def test_report_linux_system_error(mock_send_report):
     """Asserts that fields collected by the system module are present in a error report"""
-
     if not sys.platform.startswith('linux'):
         pytest.skip('this test requires linux, skipping')
 
@@ -117,28 +102,3 @@ def test_report_linux_system_error(mock_send_report):
         'performanceEntries',
         'timestampEnd',
     ])
-=======
-    assert 'aws' in report.report
-
-    for key in ['functionName', 'functionVersion', 'awsRequestId',
-                'invokedFunctionArn', 'logGroupName', 'logStreamName',
-                'memoryLimitInMB', 'getRemainingTimeInMillis']:
-        assert key in report.report['aws']
-
-    assert 'cpus' in report.report['environment']['os']
-
-    for cpu in report.report['environment']['os']['cpus']:
-        assert 'times' in cpu
-        for key in ['idle', 'irq', 'sys', 'user', 'nice']:
-            assert key in cpu['times']
-
-    assert 'freemem' in report.report['environment']['os']
-    assert 'totalmem' in report.report['environment']['os']
-
-    for key in ['utime', 'stime', 'cutime', 'cstime', 'rss']:
-        assert key in report.report['environment']['os']['linux']['pid']['self']['stat']
-        assert key in report.report['environment']['os']['linux']['pid']['self']['stat_start']
-
-    for key in ['VmRSS', 'Threads', 'FDSize']:
-        assert key in report.report['environment']['os']['linux']['pid']['self']['status']
->>>>>>> Fix sys.platform checks, add report test to check for system fields


### PR DESCRIPTION
Based on #106

This adds timeout handling similar to the node agent. The timeout window is
configured via the `timeout_window` config value. Currently this is 150
milliseconds, but because the current `system` module reads aren't async / run
in parallel this likely won't be enough of a window.

Two ways to address this are:

1. Initially profile existing `system` reads and set `timeout_window`
   accordingly.
2. Make `system` run in parallel when possible so that it's window is closer
   to 150 milliseconds.