### PR TITLE
Add docs for using Chalice, update decorator to accept class instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,28 @@ def handler(event, context):
 
 This makes it easy to add custom data and telemetry within your function.
 
+## Framework Integration
+
+### Chalice
+
+Using IOpipe with the [Chalice](https://github.com/aws/chalice) framework is easy. Just wrap your `app` like so:
+
+```python
+from chalice import Chalice
+from iopipe import IOpipe
+
+iopipe = IOpipe()
+
+app = Chalice(app_name='helloworld')
+
+@app.route("/")
+def index():
+    return {'hello': 'world'}
+
+# Do this after defining your routes
+app = iopipe(app)
+```
+
 ## License
 
 Apache 2.0

--- a/iopipe/iopipe.py
+++ b/iopipe/iopipe.py
@@ -1,5 +1,6 @@
 import decimal
 import functools
+import inspect
 import logging
 import numbers
 import warnings
@@ -61,7 +62,11 @@ class IOpipe(object):
     def __call__(self, func):
         @functools.wraps(func)
         def wrapped(event, context):
-            logger.debug('%s.%s wrapped with IOpipe decorator' % (func.__module__, func.__name__))
+            if hasattr(func, '__name__'):
+                func_name = func.__name__
+            elif hasattr(func, '__class__'):
+                func_name = func.__class__.__name__
+            logger.debug('%s.%s wrapped with IOpipe decorator' % (func.__module__, func_name))
 
             # if env var IOPIPE_ENABLED is set to False skip reporting
             if self.config['enabled'] is False:

--- a/iopipe/iopipe.py
+++ b/iopipe/iopipe.py
@@ -62,11 +62,7 @@ class IOpipe(object):
     def __call__(self, func):
         @functools.wraps(func)
         def wrapped(event, context):
-            if hasattr(func, '__name__'):
-                func_name = func.__name__
-            elif hasattr(func, '__class__'):
-                func_name = func.__class__.__name__
-            logger.debug('%s.%s wrapped with IOpipe decorator' % (func.__module__, func_name))
+            logger.debug('%s wrapped with IOpipe decorator' % repr(func))
 
             # if env var IOPIPE_ENABLED is set to False skip reporting
             if self.config['enabled'] is False:

--- a/iopipe/iopipe.py
+++ b/iopipe/iopipe.py
@@ -1,6 +1,5 @@
 import decimal
 import functools
-import inspect
 import logging
 import numbers
 import warnings


### PR DESCRIPTION
The IOpipe python agent almost supports the Chalice framework out-of-the-box. Only change that needed to be made was to update a debug message that was expecting a `__name__` that wasn't there. Otherwise IOpipe wraps cleanly around Chalice's `__call__` method.