### PR TITLE
Removing unused fields from report

### DIFF
--- a/iopipe/mock_system.py
+++ b/iopipe/mock_system.py
@@ -1,6 +1,6 @@
 import uuid
 
-from .system import read_arch, read_hostname  # noqa
+from .system import read_hostname  # noqa
 
 
 def read_bootid():

--- a/iopipe/report.py
+++ b/iopipe/report.py
@@ -29,10 +29,9 @@ class Report(object):
         :param config: The IOpipe agent config.
         :param context: The AWS Lambda context.
         """
-        self.sent = False
         self.start_time = monotonic()
+        self.sent = False
         self.stat_start = system.read_pid_stat('self')
-
         self.config = config
         self.context = context
         self.custom_metrics = []
@@ -116,15 +115,12 @@ class Report(object):
         if error:
             self.retain_error(error)
 
-        duration = monotonic() - self.start_time
-
         self.report['environment']['host']['boot_id'] = system.read_bootid()
 
         meminfo = system.read_meminfo()
 
         self.report.update({
             'aws': self.extract_context_data(),
-            'duration': int(duration * 1e9),
             'timestampEnd': int(time.time() * 1000),
         })
 
@@ -143,6 +139,8 @@ class Report(object):
                 'status': system.read_pid_status('self'),
             },
         }
+
+        self.report['duration'] = int((monotonic() - self.start_time) * 1e9)
 
         logger.debug('Sending report to IOpipe:')
         logger.debug(json.dumps(self.report, indent=2, sort_keys=True))

--- a/iopipe/report.py
+++ b/iopipe/report.py
@@ -1,4 +1,3 @@
-import datetime
 import json
 import logging
 import platform
@@ -61,6 +60,7 @@ class Report(object):
             'installMethod': self.config.get('install_method'),
             'plugins': self.plugins,
             'processId': constants.PROCESS_ID,
+            'timestamp': int(time.time() * 1000),
         }
 
         constants.COLDSTART = False
@@ -100,7 +100,6 @@ class Report(object):
             'name': type(error).__name__,
             'message': '{}'.format(error),
             'stack': traceback.format_exc(),
-            'time_reported': datetime.datetime.now().strftime(constants.TIMESTAMP_FORMAT),
         }
         self.report['errors'] = details
 
@@ -121,23 +120,19 @@ class Report(object):
 
         self.report['environment']['host']['boot_id'] = system.read_bootid()
 
-        self.report['environment']['os']['linux']['mem'] = meminfo = system.read_meminfo()
+        meminfo = system.read_meminfo()
 
         self.report.update({
             'aws': self.extract_context_data(),
             'duration': int(duration * 1e9),
-            'time_sec': int(duration),
-            'time_nanosec': int((duration - int(duration)) * 1e9),
-            'timestamp': int(time.time() * 1000),
+            'timestampEnd': int(time.time() * 1000),
         })
 
         self.report['environment']['os'].update({
-            'arch': system.read_arch(),
             'cpus': system.read_stat(),
             'freemem': meminfo['MemFree'],
             'hostname': system.read_hostname(),
             'totalmem': meminfo['MemTotal'],
-            'uptime': system.read_uptime(),
             'usedmem': meminfo['MemTotal'] - meminfo['MemFree'],
         })
 

--- a/iopipe/system.py
+++ b/iopipe/system.py
@@ -1,15 +1,4 @@
-import platform
 import socket
-
-
-def read_arch():
-    """
-    Returns the system architecture.
-
-    :returns: The system architecture.
-    :rtype: str
-    """
-    return platform.machine()
 
 
 def read_bootid():
@@ -68,7 +57,6 @@ def read_pid_stat(pid):
         'stime': int(stat[13]),
         'cutime': int(stat[15]),
         'cstime': int(stat[16]),
-        'rss': int(stat[23])
     }
 
 
@@ -85,10 +73,11 @@ def read_pid_status(pid):
         for row in status_file:
             line = row.split(":")
             status_value = line[1].rstrip("\t\n kB").lstrip()
-            try:
-                data[line[0]] = int(status_value)
-            except ValueError:
-                data[line[0]] = status_value
+            if line[0] in ['FDSize', 'Threads', 'VmRSS']:
+                try:
+                    data[line[0]] = int(status_value)
+                except ValueError:
+                    data[line[0]] = status_value
     return data
 
 
@@ -109,7 +98,6 @@ def read_stat():
             if len(cpu_stat[0]) == 3:
                 continue
             data.append({
-                'name': cpu_stat[0],
                 'times': {
                     'user': int(cpu_stat[1]),
                     'nice': int(cpu_stat[2]),
@@ -119,15 +107,3 @@ def read_stat():
                 }
             })
     return data
-
-
-def read_uptime():
-    """
-    Returns the system uptime.
-
-    :returns: The system uptime.
-    :rtype: int
-    """
-    with open('/proc/uptime') as uptime_file:
-        utf = uptime_file.readline().split(" ")
-    return int(float(utf[0]))

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -27,6 +27,10 @@ def assert_valid_schema(obj, schema=None, path=None, optional_fields=None):
     if not optional_fields:
         optional_fields = []
 
+    for key in obj:
+        key_path = '.'.join(path + [key])
+        assert key in schema, "%s not in schema" % key_path
+
     for key in schema:
         key_path = '.'.join(path + [key])
 
@@ -73,7 +77,6 @@ def test_report_linux_system_success(mock_send_report):
         'memory',
         'projectId',
         'performanceEntries',
-        'timestampEnd',
     ])
 
 
@@ -100,5 +103,4 @@ def test_report_linux_system_error(mock_send_report):
         'memory',
         'projectId',
         'performanceEntries',
-        'timestampEnd',
     ])

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1,14 +1,9 @@
-import platform
 import socket
 import sys
 
 import pytest
 
 from iopipe import system
-
-
-def test_read_arch():
-    assert system.read_arch() == platform.machine()
 
 
 def test_read_bootid():
@@ -38,7 +33,7 @@ def test_read_pid_stat():
 
     stat = system.read_pid_stat('self')
 
-    for key in ['utime', 'stime', 'cutime', 'cstime', 'rss']:
+    for key in ['utime', 'stime', 'cutime', 'cstime']:
         assert key in stat
 
 
@@ -63,10 +58,3 @@ def test_read_stat():
 
         for key in ['idle', 'irq', 'sys', 'user', 'nice']:
             assert key in cpu['times']
-
-
-def test_read_uptime():
-    if not sys.platform.startswith('linux'):
-        pytest.skip('this test requires linux, skipping')
-
-    assert system.read_uptime() > 0


### PR DESCRIPTION
Closes #111
Closes #110

This removes a number of fields that don't appear in the `schema.json` and updates the schema validator to assert that unused fields not present in the report. Adding @ewindisch as there may be fields in here that we want to add to the `schema.json` at some point.