### PR TITLE
Remove pkg_resources import

### DIFF
--- a/iopipe/constants.py
+++ b/iopipe/constants.py
@@ -1,4 +1,3 @@
-import pkg_resources
 import time
 import uuid
 
@@ -6,4 +5,4 @@ COLDSTART = True
 MODULE_LOAD_TIME = time.time() * 1000
 PROCESS_ID = str(uuid.uuid4())
 TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
-VERSION = pkg_resources.get_distribution('iopipe').version
+VERSION = '0.9.2'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='iopipe',
-    version='0.9.1',
+    version='0.9.2',
     description='IOpipe agent for serverless Application Performance Monitoring',
     author='IOpipe',
     author_email='support@iopipe.com',


### PR DESCRIPTION
Apparently some Python Lambda AMIs don't include `pkg_resources` which is
supposed to be a part of the Python stdlib. This hotfix removes that import from the `constants` module.