### PR TITLE
Reduce timeout window to 0.5 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Debug mode will log all data sent to IOpipe servers. This is also a good way to 
 
 Conditionally enable/disable the agent. For example, you will likely want to disabled the agent during development. The environment variable `$IOPIPE_ENABLED` will also be checked.
 
-#### `timeout_window` (float|int: optional = 1.5)
+#### `timeout_window` (float|int: optional = 0.5)
 
-By default, IOpipe will capture timeouts by exiting your function 1.5 seconds early from the AWS configured timeout, to allow time for reporting. You can disable this feature by setting `timeout_window` to `0` in your configuration. If not supplied, the environment variable `$IOPIPE_TIMEOUT_WINDOW` will be used if present.
+By default, IOpipe will capture timeouts by exiting your function 0.5 seconds early from the AWS configured timeout, to allow time for reporting. You can disable this feature by setting `timeout_window` to `0` in your configuration. If not supplied, the environment variable `$IOPIPE_TIMEOUT_WINDOW` will be used if present.
 
 ### Reporting Exceptions
 

--- a/acceptance/serverless/handler.py
+++ b/acceptance/serverless/handler.py
@@ -36,7 +36,7 @@ def success(event, context):
 
 @iopipe
 def timeout(event, context):
-    time.sleep(4)
+    time.sleep(2)
     return {'message': 'Invocation success'}
 
 

--- a/acceptance/serverless/serverless.yml
+++ b/acceptance/serverless/serverless.yml
@@ -59,13 +59,13 @@ functions:
       - schedule: rate(10 minutes)
     handler: handler.timeout
     runtime: python2.7
-    timeout: 2
+    timeout: 1
   py3-timeout:
     events:
       - schedule: rate(10 minutes)
     handler: handler.timeout
     runtime: python3.6
-    timeout: 2
+    timeout: 1
 
   py2-tracing:
     events:

--- a/iopipe/config.py
+++ b/iopipe/config.py
@@ -15,7 +15,7 @@ def set_config(**config):
     config.setdefault('network_timeout', 5)
     config.setdefault('path', get_collector_path())
     config.setdefault('plugins', [])
-    config.setdefault('timeout_window', os.getenv('IOPIPE_TIMEOUT_WINDOW', 1.5))
+    config.setdefault('timeout_window', os.getenv('IOPIPE_TIMEOUT_WINDOW', 0.5))
     config.setdefault('token', os.getenv('IOPIPE_TOKEN') or os.getenv('IOPIPE_CLIENTID') or '')
 
     if 'client_id' in config:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -61,7 +61,7 @@ def test_erroring(mock_send_report, handler_that_errors, mock_context):
 def test_timeouts(mock_send_report, handler_that_timeouts, mock_context):
     """Assert that the agent timeouts before function does"""
     iopipe, handler = handler_that_timeouts
-    mock_context.set_remaining_time_in_millis(2000)
+    mock_context.set_remaining_time_in_millis(1000)
 
     try:
         handler(None, mock_context)
@@ -76,8 +76,8 @@ def test_timeouts_disable(mock_send_report, handler_that_timeouts, mock_context)
     """Assert the timeout is disabled if insufficient time remaining"""
     iopipe, handler = handler_that_timeouts
 
-    # The default is 1.5, so 1500 / 100 - 1.5 = 0
-    mock_context.set_remaining_time_in_millis(1500)
+    # The default is 0.5, so 500 / 1000 - 0.5 = 0
+    mock_context.set_remaining_time_in_millis(500)
 
     try:
         handler(None, mock_context)


### PR DESCRIPTION
Due to the removal of system reads that weren't being used in the report, the
execution time for the remaining system reads is reduced. The original value
of 1.5 seconds was a conservative window, 0.5 offers a 0.2 second buffer.