### PR TITLE
Revise setup.py and MANIFEST.in to include submodules and exclude tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include *.py *.md LICENSE
+include *.md LICENSE
 recursive-include iopipe *.py

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import find_packages, setup
 
 setup(
     name='iopipe',
@@ -7,7 +7,7 @@ setup(
     author='IOpipe',
     author_email='support@iopipe.com',
     url='https://github.com/iopipe/iopipe-python',
-    packages=['iopipe'],
+    packages=find_packages(exclude=('tests', 'tests.*',)),
     extras_require={
         'dev': ['flake8', 'requests'],
     },


### PR DESCRIPTION
The `packages` entries of the setup() function wasn't including submodules, use of `find_packages` resolves this and excludes tests from the package.