### PR TITLE
Adding marker tests, minor measure behavior change

### DIFF
--- a/iopipe/contrib/trace/marker.py
+++ b/iopipe/contrib/trace/marker.py
@@ -8,5 +8,8 @@ class Marker(object):
     def end(self, name):
         self.timeline.mark('end:%s' % name)
 
-    def measure(self, name, start, end):
-        self.timeline.measure('measure:%s' % name, 'start:%s' % start, 'end:%s' % end)
+    def measure(self, name, start=None, end=None):
+        self.timeline.measure(
+            'measure:%s' % name,
+            'start:%s' % (start or name),
+            'end:%s' % (end or start or name))

--- a/iopipe/contrib/trace/timeline.py
+++ b/iopipe/contrib/trace/timeline.py
@@ -50,13 +50,15 @@ class Timeline(object):
         return [d for d in self.data if d.entryType == type]
 
     def measure(self, name, start, end=None):
-        start_mark = self.get_entries_by_name(start)[-1]
+        start_mark = self.get_entries_by_name(start)
+        start_mark = start_mark[-1] if start_mark else None
         start_time = start_mark.startTime if start_mark else self.init_time - get_offset(self)
         timestamp = start_mark.timestamp if start_mark else None
 
         end_time = self.now()
         if end is not None:
-            end_mark = self.get_entries_by_name(end)[-1]
+            end_mark = self.get_entries_by_name(end)
+            end_mark = end_mark[-1] if end_mark else None
             end_time = end_mark.startTime if end_mark else end_time
 
         duration = end_time - start_time

--- a/tests/contrib/trace/conftest.py
+++ b/tests/contrib/trace/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 
 from iopipe import IOpipe
+from iopipe.contrib.trace.marker import Marker
 from iopipe.contrib.trace import TracePlugin
 from iopipe.contrib.trace.timeline import Timeline
 
@@ -53,6 +54,11 @@ def handler_with_auto_measure(iopipe_with_auto_measure):
         context.iopipe.mark.start('foo')
         context.iopipe.mark.end('foo')
     return iopipe_with_auto_measure, _handler
+
+
+@pytest.fixture
+def marker(timeline):
+    return Marker(timeline)
 
 
 @pytest.fixture

--- a/tests/contrib/trace/test_marker.py
+++ b/tests/contrib/trace/test_marker.py
@@ -1,0 +1,33 @@
+def test_marker__measure_no_start_or_end(marker):
+    marker.start('foobar')
+    marker.end('foobar')
+    marker.measure('foobar')
+
+    assert len(marker.timeline.get_entries()) == 3
+    assert any([e.name == 'measure:foobar' for e in marker.timeline.get_entries()])
+
+
+def test_marker__measure_start_only(marker):
+    marker.start('foobar')
+    marker.end('foobar')
+    marker.end('barbaz')
+    marker.measure('barbaz', 'foobar')
+
+    assert len(marker.timeline.get_entries()) == 4
+    assert any([e.name == 'measure:barbaz' for e in marker.timeline.get_entries()])
+
+
+def test_marker__measure_different_start_and_end(marker):
+    marker.start('foobar')
+    marker.end('barbaz')
+    marker.measure('barbaz', 'foobar', 'barbaz')
+
+    assert len(marker.timeline.get_entries()) == 3
+    assert any([e.name == 'measure:barbaz' for e in marker.timeline.get_entries()])
+
+
+def test_marker__measure_no_marks(marker):
+    marker.measure('foobar')
+
+    assert len(marker.timeline.get_entries()) == 1
+    assert any([e.name == 'measure:foobar' for e in marker.timeline.get_entries()])


### PR DESCRIPTION
This adds tests for the `Marker` helper that gets attached to a context at invocation-time. It also makes a minor alteration to the `measure()` method behavior. The `start` and `end` arguments are now optional. Now
`measure('foobar')` is equivalent to `measure('foobar', 'foobar', 'foobar')`
and `measure('foobar', 'barbaz')` is equivalent to `measure('foobar',
'barbaz', 'barbaz')`.

It also resolves the issue with the tracing acceptance test.