### PR TITLE
Revise zappa documentation to use `lambda_handler` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,10 @@ Using IOpipe with [Zappa](https://github.com/Miserlou/Zappa) is easy. In your pr
 
 ```python
 from iopipe import IOpipe
-from zappa.handler import LambdaHandler
+from zappa.handler import lambda_handler
 
 iopipe = IOpipe()
-
-lambda_handler = iopipe(LambdaHandler.lambda_handler)
+lambda_handler = iopipe(lambda_handler)
 ```
 
 Then in your `zappa_settings.json` file include the following:


### PR DESCRIPTION
Zappa has a classmethod called `LambdaHandler.lambda_handler` and a separate function that just returns this classmethod. The default "lambda_handler" setting uses the function, so to avoid confusion the docs should just wrapthis function instead.