### PR TITLE
Passing report to post:report hook

### DIFF
--- a/iopipe/context.py
+++ b/iopipe/context.py
@@ -42,7 +42,10 @@ class IOpipeContext(object):
                           'This exception will not be recorded.')
             raise error
 
-        self.instance.report.send(error)
+        self.instance.report.prepare(error)
+        self.instance.run_hooks('pre:report')
+        self.instance.report.send()
+        self.instance.run_hooks('post:report')
         raise error
 
     def register(self, name, value):

--- a/iopipe/contrib/trace/plugin.py
+++ b/iopipe/contrib/trace/plugin.py
@@ -44,5 +44,5 @@ class TracePlugin(Plugin):
             add_timeline_measures(self.timeline)
         report.report['performanceEntries'] = [e._asdict() for e in self.timeline.get_entries()]
 
-    def post_report(self):
+    def post_report(self, report):
         self.timeline = Timeline()

--- a/iopipe/iopipe.py
+++ b/iopipe/iopipe.py
@@ -84,9 +84,7 @@ class IOpipe(object):
 
             self.report = Report(self.config, context)
 
-            # Partial acts as a closure here so that a reference to the report is passed to the timeout handler
-            signal.signal(signal.SIGALRM,
-                          functools.partial(self.handle_timeout, self.report))
+            signal.signal(signal.SIGALRM, self.handle_timeout)
 
             # Disable timeout if timeout_window <= 0, or if our context doesn't have a get_remaining_time_in_millis
             if self.config['timeout_window'] > 0 and \
@@ -117,11 +115,13 @@ class IOpipe(object):
                 result = func(event, context)
             except Exception as e:
                 self.run_hooks('post:invoke', event=event, context=context)
+                self.report.prepare(e)
                 self.run_hooks('pre:report')
-                self.report.send(e)
+                self.report.send()
                 raise e
             else:
                 self.run_hooks('post:invoke', event=event, context=context)
+                self.report.prepare()
                 self.run_hooks('pre:report')
                 self.report.send()
             finally:
@@ -134,18 +134,20 @@ class IOpipe(object):
 
     decorator = __call__
 
-    def handle_timeout(self, report, signum, frame):
+    def handle_timeout(self, signum, frame):
         """
         Catches a timeout (SIGALRM) and sends the report before actual timeout occurs.
 
         The signum and frame parameters are passed by the signal module to this handler.
 
-        :param report: The current report instance.
         :param signum: The signal number being handled.
         :param frame: The stack frame when signal was raised.
         """
         logger.debug('Function is about to timeout, sending report')
-        report.send()
+        self.report.prepare()
+        self.run_hooks('pre:report')
+        self.report.send()
+        self.run_hooks('post:report')
 
     def load_plugins(self, plugins):
         """
@@ -169,7 +171,7 @@ class IOpipe(object):
             'pre:invoke': lambda p: p.pre_invoke(event, context),
             'post:invoke': lambda p: p.post_invoke(event, context),
             'pre:report': lambda p: p.pre_report(self.report),
-            'post:report': lambda p: p.post_report(),
+            'post:report': lambda p: p.post_report(self.report),
         }
 
         if name in hooks:

--- a/iopipe/plugins.py
+++ b/iopipe/plugins.py
@@ -78,5 +78,5 @@ class Plugin(with_metaclass(abc.ABCMeta, object)):
         return NotImplemented
 
     @abc.abstractmethod
-    def post_report(self):
+    def post_report(self, report):
         return NotImplemented

--- a/iopipe/report.py
+++ b/iopipe/report.py
@@ -31,6 +31,7 @@ class Report(object):
         :param context: The AWS Lambda context.
         """
         self.start_time = monotonic()
+        self.prepared = False
         self.sent = False
         self.stat_start = system.read_pid_stat('self')
         self.config = config
@@ -103,15 +104,15 @@ class Report(object):
         }
         self.report['errors'] = details
 
-    def send(self, error=None):
+    def prepare(self, error=None):
         """
-        Send the current report to IOpipe.
+        Prepare the report to be sent to IOpipe.
 
         :param error: An optional error to add to report.
         """
-        if self.sent:
+        if self.prepared is True:
             return
-        self.sent = True
+        self.prepared = True
 
         if error:
             self.retain_error(error)
@@ -142,6 +143,14 @@ class Report(object):
         }
 
         self.report['duration'] = int((monotonic() - self.start_time) * 1e9)
+
+    def send(self):
+        """
+        Sends the report to IOpipe.
+        """
+        if self.sent is True:
+            return
+        self.sent = True
 
         logger.debug('Sending report to IOpipe:')
         logger.debug(json.dumps(self.report, indent=2, sort_keys=True))

--- a/iopipe/report.py
+++ b/iopipe/report.py
@@ -31,7 +31,6 @@ class Report(object):
         :param context: The AWS Lambda context.
         """
         self.start_time = monotonic()
-        self.prepared = False
         self.sent = False
         self.stat_start = system.read_pid_stat('self')
         self.config = config
@@ -110,10 +109,6 @@ class Report(object):
 
         :param error: An optional error to add to report.
         """
-        if self.prepared is True:
-            return
-        self.prepared = True
-
         if error:
             self.retain_error(error)
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -52,7 +52,7 @@ def test_plugins_incomplete_interface():
         def pre_report(self, report):
             pass
 
-        def post_report(self):
+        def post_report(self, report):
             pass
 
     plugin = CompletePlugin()

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,14 +1,11 @@
-import mock
-
 from iopipe.config import set_config
 from iopipe.report import Report
 
 
-@mock.patch('iopipe.report.send_report')
-def test_report_linux_system_success(mock_send_report, mock_context, assert_valid_schema):
+def test_report_linux_system_success(mock_context, assert_valid_schema):
     """Asserts that fields collected by the system module are present in a success report"""
     report = Report(set_config(), mock_context)
-    report.send()
+    report.prepare()
 
     assert_valid_schema(report.report, optional_fields=[
         'aws.traceId',
@@ -24,15 +21,14 @@ def test_report_linux_system_success(mock_send_report, mock_context, assert_vali
     ])
 
 
-@mock.patch('iopipe.report.send_report')
-def test_report_linux_system_error(mock_send_report, mock_context, assert_valid_schema):
+def test_report_linux_system_error(mock_context, assert_valid_schema):
     """Asserts that fields collected by the system module are present in a error report"""
     report = Report(set_config(), mock_context)
 
     try:
         raise Exception('Uh oh, this happened')
     except Exception as e:
-        report.send(e)
+        report.prepare(e)
 
     assert_valid_schema(report.report, optional_fields=[
         'aws.traceId',


### PR DESCRIPTION
* Ensures that the report is passed to the `post:report` hook.
* Ensures that the report passed to `pre:report` is the report sent to IOpipe
* Ensures that `pre:report` and `post:report` hooks are called in all report sending code paths