### PR TITLE
adding honeycomb plugin

### DIFF
--- a/iopipe/contrib/honeycomb/README.md
+++ b/iopipe/contrib/honeycomb/README.md
@@ -1,0 +1,39 @@
+# Honeycomb plugin for iopipe
+
+This plugin sends a copy of the iopipe report to Honeycomb. In order to use this plugin, you must have an account with Honeycomb. You can sign up at https://honeycomb.io/signup.
+
+To enable this plugin, include it and enable it in your initialization of iopipe:
+
+``` python
+from iopipe.contrib.honeycomb import HoneycombReport
+
+iopipe = IOpipe(token=mytoken, plugins=[HoneycombReport])
+```
+
+The plugin needs some configuration:
+
+* Honeycomb write key (available from https://ui.honeycomb.io/account)
+* Honeycomb dataset name (your choice)
+* Sample Rate (optional, defaults to 1)
+
+All three of these attributes can be configured via Lambda environment variables (in the same way the IOPipe Token is configured).  Set the following variables:
+
+* Write key: `IOPIPE_HONEYCOMB_WRITEKEY`
+* Dataset name: `IOPIPE_HONEYCOMB_DATASET`
+* Sample Rate: `IOPIPE_HONEYCOMB_SAMPLE_RATE`
+
+It is strongly advised that (after the dataset has been created) you enable unpacking of nested JSON (configurable at the bottom of the Schema page).
+
+Once the plugin is configured and successfully sending events to Honeycomb, you can augment the events with the iopipe `log` function call. Use it to record any measurements you want to take or attributes of your function you wish to use in Honeycomb. This can include timers, user IDs, log lines indicating branching, and so on.
+
+This plugin also works well with the `TracePlugin` - if you enable it as well, all the tracing data will automatically be included in the reports sent to Honeycomb.
+
+## Troubleshooting
+
+If you set this up and don't see the Honeycomb dataset being created, enable debugging by adding `debug=True` to your `iopipe` initialization:
+
+``` python
+iopipe = IOpipe(token=mytoken, debug=True, plugins=[HoneycombReport])
+```
+
+After turning on debug logging, you'll have some extra lines available via CloudWatch Logs. The line you'll be interested in is "got response from Honeycomb". For example, if the write key is not getting successfully set, you'll see this: `[DEBUG] 2018-01-02T23:07:00.722Z a3254b9d-f011-11e7-b7fd-351db3c48dd2 got response from Honeycomb: {'body': u'{"error":"unknown Team key - check your credentials"}', 'status_code': 401, 'duration': 197.627, 'metadata': None, 'error': ''}` (by comparison, a successful send to Honeycomb with debugging enabled will have that line but the `'status_code':` will be `200` instead of `401`)

--- a/iopipe/contrib/honeycomb/__init__.py
+++ b/iopipe/contrib/honeycomb/__init__.py
@@ -1,0 +1,1 @@
+from .plugin import HoneycombReport  # noqa

--- a/iopipe/contrib/honeycomb/plugin.py
+++ b/iopipe/contrib/honeycomb/plugin.py
@@ -1,0 +1,77 @@
+import logging
+import os
+import libhoney
+
+from iopipe.plugins import Plugin
+from .send_honeycomb import send_honeycomb
+
+logger = logging.getLogger(__name__)
+
+class HoneycombReport(Plugin):
+    def __init__(self):
+        config = {}
+        config['writekey'] = os.getenv('IOPIPE_HONEYCOMB_WRITEKEY', 'unsetwk')
+        config['dataset'] = os.getenv('IOPIPE_HONEYCOMB_DATASET', 'unsetds')
+        config['sample_rate'] = os.getenv('IOPIPE_HONEYCOMB_SAMPLE_RATE', 1)
+        self.config = config
+        logger.debug("initializing Honeycomb plugin with {}".format(config))
+
+    @property
+    def name(self):
+        return 'ioreport'
+
+    @property
+    def version(self):
+        return '0.1.0'
+
+    @property
+    def homepage(self):
+        return 'https://github.com/iopipe/iopipe-python'
+
+    @property
+    def enabled(self):
+        return True
+
+    def pre_setup(self, iopipe):
+        pass
+
+    def post_setup(self, iopipe):
+        # if there's iopipe config, override our defaults.
+        for c in ['writekey', 'dataset', 'sample_rate', 'api_host']:
+            if c in iopipe.config:
+                self.config[c] = iopipe.config[c]
+
+        # default sample rate to 1
+        try:
+            self.config['sample_rate'] = int(self.config['sample_rate'])
+        except ValueError:
+            self.config['sample_rate'] = 1
+        if self.config['sample_rate'] < 1:
+            self.config['sample_rate'] = 1
+
+        libhoney.init(**self.config)
+
+    def pre_invoke(self, event, context):
+        pass
+
+    def post_invoke(self, event, context):
+        pass
+
+    def pre_report(self, report):
+        pass
+
+    def post_report(self, report):
+        try:
+            send_honeycomb(report.report, self.config)
+        except Exception as e:
+            logger.debug("caught exception while sending report: {}".format(e))
+        finally:
+            logger.debug("sent report to honeycomb")
+
+        responses = libhoney.responses()
+        resp = responses.get()
+        if resp == None:
+            logger.info("no response from honeycomb")
+        else:
+            logger.debug("got response from Honeycomb: {}".format(resp))
+        libhoney.close()

--- a/iopipe/contrib/honeycomb/plugin.py
+++ b/iopipe/contrib/honeycomb/plugin.py
@@ -9,6 +9,7 @@ from .send_honeycomb import format_report
 
 logger = logging.getLogger(__name__)
 
+
 class HoneycombReport(Plugin):
     def __init__(self):
         config = {}
@@ -74,7 +75,7 @@ class HoneycombReport(Plugin):
 
         responses = libhoney.responses()
         resp = responses.get()
-        if resp == None:
+        if resp is None:
             logger.info("no response from honeycomb")
         else:
             logger.debug("got response from Honeycomb: {}".format(resp))

--- a/iopipe/contrib/honeycomb/plugin.py
+++ b/iopipe/contrib/honeycomb/plugin.py
@@ -1,9 +1,11 @@
 import logging
 import os
+import copy
 import libhoney
 
 from iopipe.plugins import Plugin
 from .send_honeycomb import send_honeycomb
+from .send_honeycomb import format_report
 
 logger = logging.getLogger(__name__)
 
@@ -61,8 +63,10 @@ class HoneycombReport(Plugin):
         pass
 
     def post_report(self, report):
+        local_rep = copy.deepcopy(report.report)
+        format_report(local_rep)
         try:
-            send_honeycomb(report.report, self.config)
+            send_honeycomb(local_rep, self.config)
         except Exception as e:
             logger.debug("caught exception while sending report: {}".format(e))
         finally:

--- a/iopipe/contrib/honeycomb/send_honeycomb.py
+++ b/iopipe/contrib/honeycomb/send_honeycomb.py
@@ -1,0 +1,33 @@
+import logging
+import libhoney
+
+logger = logging.getLogger(__name__)
+
+def send_honeycomb(report, config):
+    """
+    Sends the report to Honeycomb.
+
+    :param report: The report to be sent.
+    :param config: The IOpipe agent configuration.
+    """
+
+    custom = {}
+    for log in report['custom_metrics']:
+        name = log['name']
+        # undo decimal typecast to strings
+        if 'n' in log:
+            val = log['n']
+        elif 's' in log:
+            val = log['s']
+        else:
+            val = None
+            custom['hny_translation_err'] = "not_n_or_s for key {}".format(name)
+        custom[name] = val
+    report['custom'] = custom
+    try:
+        ev = libhoney.Event()
+        ev.add(report)
+        ev.send()
+    except Exception as e:
+        logger.info('Error sending report to Honeycomb: %s' % e)
+

--- a/iopipe/contrib/honeycomb/send_honeycomb.py
+++ b/iopipe/contrib/honeycomb/send_honeycomb.py
@@ -3,6 +3,7 @@ import libhoney
 
 logger = logging.getLogger(__name__)
 
+
 def format_report(report):
     """
     Munges the report format to be more honeycomb-friendly
@@ -54,4 +55,3 @@ def send_honeycomb(report, config):
         ev.send()
     except Exception as e:
         logger.info('Error sending report to Honeycomb: %s' % e)
-

--- a/iopipe/contrib/honeycomb/send_honeycomb.py
+++ b/iopipe/contrib/honeycomb/send_honeycomb.py
@@ -3,6 +3,43 @@ import libhoney
 
 logger = logging.getLogger(__name__)
 
+def format_report(report):
+    """
+    Munges the report format to be more honeycomb-friendly
+    """
+    # munge custom metrics
+    if 'custom_metrics' in report:
+        custom = {}
+        for log in report['custom_metrics']:
+            name = log['name']
+            # undo decimal typecast to strings
+            if 'n' in log:
+                val = log['n']
+            elif 's' in log:
+                val = log['s']
+            else:
+                val = None
+                custom['hny_translation_err'] = "not_n_or_s for key {}".format(name)
+            custom[name] = val
+        report['custom'] = custom
+
+    # munge tracing plugin's contributions. this will likely need improvement
+    # for example, could pull out matching start/end segments and calculate stuff...
+    # [{"duration":0,"entryType":"mark","name":"start:iopipe","startTime":24674,"timestamp":1514940704792},
+    # {"duration":0,"entryType":"mark","name":"end:iopipe","startTime":3229406,"timestamp":1514940704795}]
+    if 'performanceEntries' in report:
+        traces = {}
+        for mark in report['performanceEntries']:
+            trace = {
+                "duration": mark['duration'],
+                "entryType": mark['entryType'],
+                "startTime": mark['startTime'],
+                "timestamp": mark['timestamp'],
+            }
+            traces[mark['name']] = trace
+        report['traces'] = traces
+
+
 def send_honeycomb(report, config):
     """
     Sends the report to Honeycomb.
@@ -11,19 +48,6 @@ def send_honeycomb(report, config):
     :param config: The IOpipe agent configuration.
     """
 
-    custom = {}
-    for log in report['custom_metrics']:
-        name = log['name']
-        # undo decimal typecast to strings
-        if 'n' in log:
-            val = log['n']
-        elif 's' in log:
-            val = log['s']
-        else:
-            val = None
-            custom['hny_translation_err'] = "not_n_or_s for key {}".format(name)
-        custom[name] = val
-    report['custom'] = custom
     try:
         ev = libhoney.Event()
         ev.add(report)

--- a/iopipe/contrib/trace/plugin.py
+++ b/iopipe/contrib/trace/plugin.py
@@ -44,5 +44,5 @@ class TracePlugin(Plugin):
             add_timeline_measures(self.timeline)
         report.report['performanceEntries'] = [e._asdict() for e in self.timeline.get_entries()]
 
-    def post_report(self):
+    def post_report(self, report):
         self.timeline = Timeline()

--- a/iopipe/iopipe.py
+++ b/iopipe/iopipe.py
@@ -169,7 +169,7 @@ class IOpipe(object):
             'pre:invoke': lambda p: p.pre_invoke(event, context),
             'post:invoke': lambda p: p.post_invoke(event, context),
             'pre:report': lambda p: p.pre_report(self.report),
-            'post:report': lambda p: p.post_report(),
+            'post:report': lambda p: p.post_report(self.report),
         }
 
         if name in hooks:

--- a/iopipe/plugins.py
+++ b/iopipe/plugins.py
@@ -78,5 +78,5 @@ class Plugin(with_metaclass(abc.ABCMeta, object)):
         return NotImplemented
 
     @abc.abstractmethod
-    def post_report(self):
+    def post_report(self, report):
         return NotImplemented


### PR DESCRIPTION
This PR adds a `HoneycombReport` plugin that sends a copy of the iopipe report to Honeycomb. Instructions on how to use it are in the README. I expect a minor merge conflict with #135 - they both augment the `post_report` hook. 