### PR TITLE
Add generalized runtime key

### DIFF
--- a/iopipe/report.py
+++ b/iopipe/report.py
@@ -48,6 +48,12 @@ class Report(object):
                     'runtime': 'python',
                     'version': constants.VERSION,
                 },
+                'runtime': {
+                    'name': platform.python_implementation(),
+                    'version': platform.python_version()
+                },
+                # DEPRECATED: the following key will be removed in favor of
+                # the 'runtime' in the future
                 'python': {
                     'version': platform.python_version(),
                 },


### PR DESCRIPTION
Add generalized runtime key. NB: this would also mean reported runtime would change from the standard "python" to the more specific CPython (for AWS at present)