### PR TITLE
Fix trace time precision

### DIFF
--- a/iopipe/contrib/trace/timeline.py
+++ b/iopipe/contrib/trace/timeline.py
@@ -9,7 +9,7 @@ Entry = collections.namedtuple('Entry', ['name', 'startTime', 'duration', 'entry
 def time_in_millis(time=None, offset=0):
     if time is None:
         time = monotonic()
-    return int((time * 1e9) - offset)
+    return time * 1000 - offset
 
 
 def get_offset(timeline):
@@ -18,14 +18,12 @@ def get_offset(timeline):
 
 def mark_data(timeline, name, start_time=None, duration=0, entry_type='mark', timestamp=None):
     data = timeline.data or []
-    default_time = monotonic()
     entry = Entry(
         name=name,
-        startTime=start_time or time_in_millis(default_time, get_offset(timeline)),
+        startTime=start_time or time_in_millis(offset=get_offset(timeline)),
         duration=duration,
         entryType=entry_type,
-        timestamp=timestamp or int(time.time() * 1000)
-    )
+        timestamp=timestamp or int(time.time() * 1000))
     data.append(entry)
     data.sort(key=lambda i: i.startTime)
     return data
@@ -34,8 +32,8 @@ def mark_data(timeline, name, start_time=None, duration=0, entry_type='mark', ti
 class Timeline(object):
     def __init__(self, offset=0):
         self.init_time = time_in_millis()
-        self.data = []
         self.offset = offset
+        self.data = []
 
     def mark(self, name):
         self.data = mark_data(self, name=name)
@@ -64,13 +62,7 @@ class Timeline(object):
         duration = end_time - start_time
 
         self.data = mark_data(
-            self,
-            name=name,
-            start_time=start_time,
-            duration=duration,
-            entry_type='measure',
-            timestamp=timestamp
-        )
+            self, name=name, start_time=0, duration=duration, entry_type='measure', timestamp=timestamp)
 
     def clear_marks(self):
         self.data = [d for d in self.data if d['entryType'] != 'mark']
@@ -82,4 +74,4 @@ class Timeline(object):
         self.data = []
 
     def now(self):
-        return time_in_millis(monotonic(), get_offset(self))
+        return time_in_millis(offset=get_offset(self))

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,7 @@ test=pytest
 
 [flake8]
 max-line-length = 120
+
+[yapf]
+based_on_style = pep8
+column_limit = 120

--- a/tests/contrib/trace/test_plugin.py
+++ b/tests/contrib/trace/test_plugin.py
@@ -35,6 +35,9 @@ def test__trace_plugin__valid_schema(mock_send_report, handler_with_auto_measure
 
     assert_valid_schema(iopipe.report.report, optional_fields=[
         'aws.traceId',
+        'environment.runtime.vendor',
+        'environment.runtime.vmVendor',
+        'environment.runtime.vmVersion',
         'environment.nodejs',
         'errors.count',
         'errors.message',

--- a/tests/contrib/trace/test_timeline.py
+++ b/tests/contrib/trace/test_timeline.py
@@ -1,3 +1,6 @@
+import time
+
+
 def test_timeline(timeline):
     timeline.mark('start:foo')
 
@@ -22,6 +25,17 @@ def test_timeline(timeline):
 
     start_foo = timeline.get_entries_by_name('start:foo')[0]
     end_foo = timeline.get_entries_by_name('end:foo')[0]
-    measure = timeline.get_entries_by_type('measure')[0]
+    measure_foo = timeline.get_entries_by_name('foo')[0]
 
-    assert measure.duration == end_foo.startTime - start_foo.startTime
+    assert measure_foo.duration == end_foo.startTime - start_foo.startTime
+
+    timeline.mark('start:bar')
+    time.sleep(0.1)
+    timeline.mark('end:bar')
+    timeline.measure('bar', 'start:bar', 'end:bar')
+
+    start_bar = timeline.get_entries_by_name('start:bar')[0]
+    end_bar = timeline.get_entries_by_name('end:bar')[0]
+    measure_bar = timeline.get_entries_by_name('bar')[0]
+
+    assert 100.0 <= measure_bar.duration <= 150.0

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -7,18 +7,23 @@ def test_report_linux_system_success(mock_context, assert_valid_schema):
     report = Report(set_config(), mock_context)
     report.prepare()
 
-    assert_valid_schema(report.report, optional_fields=[
-        'aws.traceId',
-        'environment.nodejs',
-        'errors.count',
-        'errors.message',
-        'errors.name',
-        'errors.stack',
-        'errors.stackHash',
-        'memory',
-        'projectId',
-        'performanceEntries',
-    ])
+    assert_valid_schema(
+        report.report,
+        optional_fields=[
+            'aws.traceId',
+            'environment.runtime.vendor',
+            'environment.runtime.vmVendor',
+            'environment.runtime.vmVersion',
+            'environment.nodejs',
+            'errors.count',
+            'errors.message',
+            'errors.name',
+            'errors.stack',
+            'errors.stackHash',
+            'memory',
+            'projectId',
+            'performanceEntries',
+        ])
 
 
 def test_report_linux_system_error(mock_context, assert_valid_schema):
@@ -30,12 +35,17 @@ def test_report_linux_system_error(mock_context, assert_valid_schema):
     except Exception as e:
         report.prepare(e)
 
-    assert_valid_schema(report.report, optional_fields=[
-        'aws.traceId',
-        'environment.nodejs',
-        'errors.count',
-        'errors.stackHash',
-        'memory',
-        'projectId',
-        'performanceEntries',
-    ])
+    assert_valid_schema(
+        report.report,
+        optional_fields=[
+            'aws.traceId',
+            'environment.runtime.vendor',
+            'environment.runtime.vmVendor',
+            'environment.runtime.vmVersion',
+            'environment.nodejs',
+            'errors.count',
+            'errors.stackHash',
+            'memory',
+            'projectId',
+            'performanceEntries',
+        ])


### PR DESCRIPTION
The `duration` in the payload is `monotonic() * 1e9`. But the `duration` in the node.js trace plugin is `monotonic() * 1000`. This fixes the precision for the `duration`.