### PR TITLE
Pass method calls on StreamToLogger on to sys.__stdout__

### DIFF
--- a/acceptance/serverless-py37/handler.py
+++ b/acceptance/serverless-py37/handler.py
@@ -95,6 +95,8 @@ def logging(event, context):
     # This should still work (backwards compatibility)
     context.iopipe.log("time", time.time())
 
+    print("I'm redirecting stdout")
+
     context.iopipe.log.debug("I'm a debug message.")
     context.iopipe.log.info("I'm an info message.")
     context.iopipe.log.warn("I'm a warning message.")

--- a/acceptance/serverless-py37/serverless.yml
+++ b/acceptance/serverless-py37/serverless.yml
@@ -45,6 +45,11 @@ functions:
       - schedule: rate(5 minutes)
     handler: handler.custom_metrics
 
+  logging:
+    events:
+      - schedule: rate(15 minutes)
+    handler: handler.logging
+
   logging-tmp:
     events:
       - schedule: rate(1 hour)

--- a/acceptance/serverless/handler.py
+++ b/acceptance/serverless/handler.py
@@ -95,6 +95,8 @@ def logging(event, context):
     # This should still work (backwards compatibility)
     context.iopipe.log("time", time.time())
 
+    print("I'm redirecting stdout")
+
     context.iopipe.log.debug("I'm a debug message.")
     context.iopipe.log.info("I'm an info message.")
     context.iopipe.log.warn("I'm a warning message.")

--- a/iopipe/contrib/logger/stream.py
+++ b/iopipe/contrib/logger/stream.py
@@ -1,7 +1,14 @@
+import sys
+
+
 class StreamToLogger(object):
     def __init__(self, logger):
         self.logger = logger
 
+    def __getattr__(self, name):
+        return getattr(sys.__stdout__, name)
+
     def write(self, buf):
         for line in buf.rstrip().splitlines():
             self.logger.info(line.rstrip())
+        sys.__stdout__.write(buf)


### PR DESCRIPTION
In Python 3.7 `print()` calls `flush()` on `sys.stdout`. Make sure this and all other method calls continue to work.

Closes #299