### PR TITLE
Disable stdout redirection for python3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ If you prefer your print statements not to be logged, you can disable this by se
 iopipe = IOpipe(plugins=[LoggerPlugin(enabled=True, redirect_stdout=False)])
 ```
 
+**Note:** Due to a change to the way the python3.7 runtime configures logging, stdout redirection is disabled for this runtime. Use `context.iopipe.log.*` instead.
+
 By default the logger plugin will log messages to an in-memory buffer. If you prefer to log messages to your Lambda function's `/tmp` directory:
 
 ```python

--- a/iopipe/compat.py
+++ b/iopipe/compat.py
@@ -2,6 +2,9 @@ import io
 import sys
 
 PY3 = sys.version_info[0] == 3
+PY3 = sys.version_info[0] == 3
+PY37 = sys.version_info[0] == 3 and sys.version_info[1] == 7
+
 
 if PY3:  # pragma: no cover
     from urllib.parse import urlparse

--- a/iopipe/contrib/logger/plugin.py
+++ b/iopipe/contrib/logger/plugin.py
@@ -5,7 +5,7 @@ import os
 import sys
 import tempfile
 
-from iopipe.compat import StringIO
+from iopipe.compat import StringIO, PY37
 from iopipe.plugins import Plugin
 from iopipe.signer import get_signed_request
 
@@ -48,6 +48,11 @@ class LoggerPlugin(Plugin):
         self.logger = logging.getLogger(name)
         self.redirect_stdout = redirect_stdout
         self.use_tmp = use_tmp
+
+        # Due to a change in python3.7 runtime's logging config, we cannot redirect
+        # stdout without resulting in a recursion error.
+        if PY37:
+            self.redirect_stdout = False
 
         if self.enabled:
             self.init_handler()

--- a/tests/contrib/logger/test_plugin.py
+++ b/tests/contrib/logger/test_plugin.py
@@ -5,6 +5,7 @@ import sys
 
 import pytest
 
+from iopipe.compat import PY37
 from iopipe.system import read_disk
 
 
@@ -63,10 +64,11 @@ def test__logger_plugin(
         in stream.getvalue()
     )
 
-    assert (
-        '"message": "This is not a misprint.", "name": "testlog", "severity": "INFO"'
-        in stream.getvalue()
-    )
+    if not PY37:
+        assert (
+            '"message": "This is not a misprint.", "name": "testlog", "severity": "INFO"'
+            in stream.getvalue()
+        )
 
     stream.seek(0)
 


### PR DESCRIPTION
In the Python 3.7 runtime, lambda configures a logging handler that writes to stdout resulting in a recursion error. Disable stdout redirection in python3.7 for now.

Related to #299