### PR TITLE
Marker Check for Auto HTTP Monkey PAtching

### DIFF
--- a/iopipe/contrib/trace/auto_http.py
+++ b/iopipe/contrib/trace/auto_http.py
@@ -70,6 +70,8 @@ def patch_requests_session_send(context, http_filter, http_headers):
         return
 
     def send(self, *args, **kwargs):
+        if not hasattr(context, "iopipe") or not hasattr(context.iopipe, "mark"):
+            return original_requests_session_send(self, *args, **kwargs)
         id = ensure_utf8(str(uuid.uuid4()))
         with context.iopipe.mark(id):
             response = original_requests_session_send(self, *args, **kwargs)
@@ -96,6 +98,8 @@ def patch_botocore_session_send(context, http_filter, http_headers):
         return
 
     def send(self, *args, **kwargs):
+        if not hasattr(context, "iopipe") or not hasattr(context.iopipe, "mark"):
+            return original_botocore_session_send(self, *args, **kwargs)
         id = str(uuid.uuid4())
         with context.iopipe.mark(id):
             response = original_botocore_session_send(self, *args, **kwargs)
@@ -122,6 +126,8 @@ def patch_botocore_vendored_session_send(context, http_filter, http_headers):
         return
 
     def send(self, *args, **kwargs):
+        if not hasattr(context, "iopipe") or not hasattr(context.iopipe, "mark"):
+            return original_botocore_vendored_session_send(self, *args, **kwargs)
         id = str(uuid.uuid4())
         with context.iopipe.mark(id):
             response = original_botocore_vendored_session_send(self, *args, **kwargs)

--- a/iopipe/contrib/trace/plugin.py
+++ b/iopipe/contrib/trace/plugin.py
@@ -49,14 +49,12 @@ class TracePlugin(Plugin):
 
     def pre_invoke(self, event, context):
         self.timeline = Timeline()
-        context.iopipe.register("mark", Marker(self.timeline, context))
+        context.iopipe.register("mark", Marker(self.timeline, context), force=True)
 
         if self.auto_http is True:
             patch_http_requests(context, self.http_filter, self.http_headers)
 
     def post_invoke(self, event, context):
-        context.iopipe.unregister("mark")
-
         if self.auto_http is True:
             restore_http_requests()
 

--- a/tests/contrib/trace/conftest.py
+++ b/tests/contrib/trace/conftest.py
@@ -2,6 +2,7 @@ import pytest
 import requests
 
 from iopipe import IOpipeCore
+from iopipe.context import ContextWrapper
 from iopipe.contrib.trace.marker import Marker
 from iopipe.contrib.trace import TracePlugin
 from iopipe.contrib.trace.timeline import Timeline
@@ -16,6 +17,11 @@ def iopipe_with_trace():
         debug=True,
         plugins=[plugin],
     )
+
+
+@pytest.fixture
+def mock_context_wrapper(mock_context, iopipe_with_trace):
+    return ContextWrapper(mock_context, iopipe_with_trace)
 
 
 @pytest.fixture

--- a/tests/contrib/trace/test_auto_http.py
+++ b/tests/contrib/trace/test_auto_http.py
@@ -1,3 +1,5 @@
+import mock
+
 from botocore.httpsession import URLLib3Session as BotocoreSession
 from botocore.vendored.requests.sessions import Session as BotocoreVendoredSession
 from requests.sessions import Session as RequestsSession
@@ -5,7 +7,15 @@ from requests.sessions import Session as RequestsSession
 from iopipe.contrib.trace.auto_http import patch_http_requests, restore_http_requests
 
 
-def test_monkey_patching(mock_context):
+@mock.patch("iopipe.contrib.trace.auto_http.original_requests_session_send")
+@mock.patch("iopipe.contrib.trace.auto_http.original_botocore_session_send")
+@mock.patch("iopipe.contrib.trace.auto_http.original_botocore_vendored_session_send")
+def test_monkey_patching(
+    mock_botocore_vendored_session_send,
+    mock_botocore_session_send,
+    mock_requests_session_send,
+    mock_context_wrapper,
+):
     assert not hasattr(RequestsSession, "__monkey_patched")
     assert not hasattr(BotocoreSession, "__monkey_patched")
     assert not hasattr(BotocoreVendoredSession, "__monkey_patched")
@@ -15,11 +25,63 @@ def test_monkey_patching(mock_context):
 
     http_headers = ["Cache-Control"]
 
-    patch_http_requests(mock_context, mock_filter, http_headers)
+    patch_http_requests(mock_context_wrapper, mock_filter, http_headers)
 
     assert hasattr(RequestsSession, "__monkey_patched")
     assert hasattr(BotocoreSession, "__monkey_patched")
     assert hasattr(BotocoreVendoredSession, "__monkey_patched")
+
+    requests_session = RequestsSession()
+    requests_session.send()
+    assert mock_requests_session_send.called
+
+    botocore_session = BotocoreSession()
+    botocore_session.send()
+    assert mock_botocore_session_send.called
+
+    botocore_vendored_session = BotocoreVendoredSession()
+    botocore_vendored_session.send()
+    assert mock_botocore_vendored_session_send.called
+
+    restore_http_requests()
+
+    assert not hasattr(RequestsSession, "__monkey_patched")
+    assert not hasattr(BotocoreSession, "__monkey_patched")
+    assert not hasattr(BotocoreVendoredSession, "__monkey_patched")
+
+
+@mock.patch("iopipe.contrib.trace.auto_http.original_requests_session_send")
+@mock.patch("iopipe.contrib.trace.auto_http.original_botocore_session_send")
+@mock.patch("iopipe.contrib.trace.auto_http.original_botocore_vendored_session_send")
+def test_monkey_patching_no_iopipe(
+    mock_botocore_vendored_session_send,
+    mock_botocore_session_send,
+    mock_requests_session_send,
+    mock_context,
+):
+    assert not hasattr(RequestsSession, "__monkey_patched")
+    assert not hasattr(BotocoreSession, "__monkey_patched")
+    assert not hasattr(BotocoreVendoredSession, "__monkey_patched")
+
+    delattr(mock_context, "iopipe")
+
+    patch_http_requests(mock_context, None, None)
+
+    assert hasattr(RequestsSession, "__monkey_patched")
+    assert hasattr(BotocoreSession, "__monkey_patched")
+    assert hasattr(BotocoreVendoredSession, "__monkey_patched")
+
+    requests_session = RequestsSession()
+    requests_session.send()
+    assert mock_requests_session_send.called
+
+    botocore_session = BotocoreSession()
+    botocore_session.send()
+    assert mock_botocore_session_send.called
+
+    botocore_vendored_session = BotocoreVendoredSession()
+    botocore_vendored_session.send()
+    assert mock_botocore_vendored_session_send.called
 
     restore_http_requests()
 


### PR DESCRIPTION
The monkey patching assumes a marker is present but this may not always
be the case. For example, if the profiler plugin is loaded after the
trace plugin, then the profiler won't be provided an active marker. This
removes marker removal and makes the monkey patching defensive about the
presence of markers.