### PR TITLE
CI fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
           command: |
             unset AWS_REGION IOPIPE_DEBUG IOPIPE_ENABLED IOPIPE_TIMEOUT_WINDOW IOPIPE_TOKEN
             pip install -q ".[coverage]"
-            pip install -q -U attrs jsonscema
+            pip install -q -U attrs jsonschema
             pytest --cov=iopipe tests/
       - run:
           name: Upload coverage report

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
       - run:
           name: Check code style
           command: |
-            pip install black==19.3b0
+            pip install -q black==19.3b0
             black iopipe
             black tests
 
@@ -63,13 +63,13 @@ jobs:
           name: Generate coverage report
           command: |
             unset AWS_REGION IOPIPE_DEBUG IOPIPE_ENABLED IOPIPE_TIMEOUT_WINDOW IOPIPE_TOKEN
-            pip install ".[coverage]"
-            pip install -U attrs jsonscema
+            pip install -q ".[coverage]"
+            pip install -q -U attrs jsonscema
             pytest --cov=iopipe tests/
       - run:
           name: Upload coverage report
           command: |
-            pip install -U codecov
+            pip install -q -U codecov
             codecov
 
   acceptance:
@@ -104,7 +104,7 @@ jobs:
           name: Install release dependencies
           command: |
             sudo apt-get install -y pandoc
-            sudo pip install -U pyOpenSSL pypandoc setuptools twine
+            sudo pip install -q -U pyOpenSSL pypandoc setuptools twine
       - run:
           name: Release package
           command: |
@@ -119,7 +119,7 @@ jobs:
       - checkout
       - run:
           name: Install publish dependencies
-          command: sudo pip install -U awscli
+          command: sudo pip install -q -U awscli
       - run:
           name: Override AWS Credentials
           command: |
@@ -137,7 +137,7 @@ jobs:
       - checkout
       - run:
           name: Install publish dependencies
-          command: sudo pip install -U awscli
+          command: sudo pip install -q -U awscli
       - run:
           name: Override AWS Credentials
           command: |

--- a/iopipe/contrib/trace/plugin.py
+++ b/iopipe/contrib/trace/plugin.py
@@ -36,7 +36,7 @@ class TracePlugin(Plugin):
         :param http_headers: Additional HTTP headers to collect
         :type http_headers: list|tuple
         :param auto_db: Whether or not to automatically trace database requests
-        :type auto_http: bool
+        :type auto_db: bool
         """
         self.auto_measure = auto_measure
         self.auto_http = auto_http

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ tests_require = [
     "psycopg2-binary==2.8.3",
     "pymongo==3.8.0",
     "PyMySQL==0.9.3",
-    "pytest==4.1.0",
+    "pytest==4.6.6",
     "pytest-benchmark==3.2.0",
     "redis==3.3.4",
     "requests",

--- a/tests/test_send_report.py
+++ b/tests/test_send_report.py
@@ -4,6 +4,7 @@ from iopipe.config import set_config
 from iopipe.send_report import send_report
 
 
+@mock.patch("os.environ", {})
 @mock.patch("iopipe.send_report.session", autospec=True)
 def test_send_report(mock_session):
     """Assert that a POST request is made when a report is sent"""
@@ -17,6 +18,7 @@ def test_send_report(mock_session):
     )
 
 
+@mock.patch("os.environ", {})
 @mock.patch("iopipe.send_report.session", autospec=True)
 def test_send_report_network_timeout(mock_session):
     """Assert that the timeout is changed when network_timeout is set"""


### PR DESCRIPTION
### Summary

I noticed that CI is failing because of outdated `pytest`. They fixed compatibility with `attrs` package in newer versions, so I bumped it to the last version that supports `py27`.

### Changes

- Fix docstring for `TracePlugin`
- Make `pip install` quiet in CI for better log output
- Fix `jsonschema` package name to fix coverage CI
- Update `pytest` to `4.6.6` for compatibility with `attrs`
- Fix unit tests for `send_report` to not depend on `ENV`